### PR TITLE
Fully implement CVD color schemes and sync matplotlib/ROOT examples

### DIFF
--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -167,19 +167,13 @@ def Hist2DContour(pdf):
 
     # If you need to calculate the covariance yourself, use numpy's method
     #npcov = np.cov([throws[:,0],throws[:,1]], rowvar=True)
-
-    ellip_1sig = CovEllipse(throws[:,0], throws[:,1], cov, nsig=1, 
-                             edgecolor='firebrick', label=r"1$\sigma$",
-                             linewidth=2)
-    ellip_2sig = CovEllipse(throws[:,0], throws[:,1], cov, nsig=2, 
-                             edgecolor='fuchsia', label=r"2$\sigma$", 
-                             linewidth=2, linestyle='--')
-    ellip_3sig = CovEllipse(throws[:,0], throws[:,1], cov, nsig=3, 
-                             edgecolor='cyan', label=r"3$\sigma$", 
-                             linewidth=2, linestyle=':')
-    ax.add_patch(ellip_1sig)
-    ax.add_patch(ellip_2sig)
-    ax.add_patch(ellip_3sig)
+    cyc = cycler(edgecolor=plt.rcParams["axes.prop_cycle"].by_key()["color"]) + cycler(linestyle=["-", "--", ":"]*10)[:len(plt.rcParams["axes.prop_cycle"])]
+    cyc = cyc()
+    for nsig in range(1,4):
+        ellipse = CovEllipse(throws[:,0], throws[:,1], cov, nsig=nsig,
+                             label=r"{0}$\sigma$".format(nsig),
+                             linewidth=2, **next(cyc))
+        ax.add_patch(ellipse)
 
     ax.set_xlabel("x label")
     ax.set_ylabel("y label")

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -49,9 +49,7 @@ def Hist1D(pdf):
 
 
     plt.figure()
-    plt.style.use('tableau-colorblind10')
     ax = plt.axes()
-    ax.spines[:].set_color('black')
     plt.hist(x, histtype='step', label="Hist", linewidth=2)
     plt.xlabel('x label')
     plt.ylabel('y label')

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -23,17 +23,14 @@ N_HISTS = 8   # exhibits all the colors in the Okabe-Ito cycler
 def Hist1D(pdf):
     x = np.random.normal(0, 1, 1000)
 
-
     plt.figure()
     ax = plt.axes()
     plt.hist(x, histtype='step', label="Hist", range=(-5, 5), bins=50)
     plt.xlabel('x label')
     plt.ylabel('y label')
     plt.xlim(-5,5)
-    plt.legend()
     ax.set_ylim(0, 1.2*ax.get_ylim()[1])
-    dunestyle.WIP()
-    dunestyle.SimulationSide()
+    dunestyle.Simulation()
     plt.savefig("example.matplotlib.hist1D.png")
     pdf.savefig()
 
@@ -81,8 +78,8 @@ def DataMC(pdf):
     residuals = diff / fit_at_bin_ctrs
     chi2 = (diff**2/fit_at_bin_ctrs).sum()
 
-    # this is the way ROOT counts deg of freedom,
-    # so we mimic it for consistency
+    # this way (count only nonzero bins) is the way ROOT counts deg of freedom,
+    # so we mimic it for consistency (not nec. correctness)
     from inspect import signature
     ndf = np.count_nonzero(counts > 0) - len(signature(Gauss).parameters)
 
@@ -112,7 +109,8 @@ def DataMC(pdf):
     axs[0].legend(fontsize="x-large")  # since the upper panel is only 70% of the whole canvas, the legend is (by default) too
     axs[0].set_xlim(-5,5)
     axs[0].set_ylim(bottom=0)
-    dunestyle.CornerLabel("MC/Data Comparison Example", ax=axs[0])
+
+    dunestyle.Preliminary(x=0.02, ax=axs[0], fontsize="xx-large")
 
     # Bottom plot
     axs[1].errorbar(x=bin_centers[mask], y=residuals[mask], yerr=frac_errors[mask],
@@ -147,8 +145,11 @@ def Hist2DContour(pdf):
     # https://stackoverflow.com/questions/42387471/how-to-add-a-colorbar-for-a-hist2d-plot
     fig.colorbar(hist2d[3])
 
-    # If you need to calculate the covariance yourself, use numpy's method
-    #npcov = np.cov([throws[:,0],throws[:,1]], rowvar=True)
+    # we want to cycle both the colors AND the line-styles,
+    # so we combine cyclers.
+    # unfortunately since they have different numbers of items,
+    # we need to force the line-style one to repeat a few times,
+    # then chop off the excess
     cyc = cycler(edgecolor=plt.rcParams["axes.prop_cycle"].by_key()["color"]) + cycler(linestyle=["-", "--", ":"]*10)[:len(plt.rcParams["axes.prop_cycle"])]
     cyc = cyc()
     for nsig in range(1,4):
@@ -156,6 +157,7 @@ def Hist2DContour(pdf):
                              label=r"{0}$\sigma$".format(nsig), **next(cyc))
         ax.add_patch(ellipse)
 
+    ax.set_ylim(top=1.3*ax.get_ylim()[1])  # make a little space for the "DUNE simulation" label
     ax.set_xlabel("x label")
     ax.set_ylabel("y label")
     dunestyle.Simulation()
@@ -177,7 +179,6 @@ def HistStacked(pdf):
     ax.set_xlim(-2*(N_HISTS/2+2), 2*N_HISTS)
     ax.set_ylim(0, 1.2*ax.get_ylim()[1])
     dunestyle.WIP()
-    dunestyle.SimulationSide()
     plt.legend()
     plt.savefig("example.matplotlib.histstacked.png")
     pdf.savefig()
@@ -196,7 +197,6 @@ def HistOverlay(pdf):
     ax.set_xlim(-2*(N_HISTS/2+2), 2*N_HISTS)
     ax.set_ylim(0, 1.2*ax.get_ylim()[1])
     dunestyle.WIP()
-    dunestyle.SimulationSide()
     plt.legend()
     plt.savefig("example.matplotlib.histoverlay.png")
     pdf.savefig()

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -19,30 +19,6 @@ from plotting_helpers import Gauss, CovEllipse
 # how many histograms to draw in multi-hist plots
 N_HISTS = 8   # exhibits all the colors in the Okabe-Ito cycler
 
-### Simple 1D Gaussian example ###
-def Gauss1D(pdf):
-    x = np.linspace(-5, 5, 500)
-    y = scipy.stats.norm.pdf(x)
-
-    # Set axex color. For specific axes, you can use e.g.
-    # ax.spines['left'].set_color()
-    # Also, note this needs to come before plt.plot() or else
-    # matplotlib freaks out
-    ax = plt.axes()
-    ax.spines[:].set_color('black')
-
-    plt.plot(x, y, label="Gaussian")
-    plt.xlabel("x label")
-    plt.ylabel("y label")
-    plt.legend()
-
-    # Scale y-axis so "Work in Progress" watermark fits in frame
-    ax.set_ylim(0, 1.2*ax.get_ylim()[1])
-    dunestyle.WIP()
-    dunestyle.SimulationSide()
-    plt.savefig("example.matplotlib.gaus.png")
-    pdf.savefig()
-
 ### 1D histogram example ###
 def Hist1D(pdf):
     x = np.random.normal(0, 1, 1000)
@@ -235,7 +211,6 @@ def HistOverlay(pdf):
 if __name__ == '__main__':
     pdf = PdfPages("example.matplotlib.pdf")
 
-    Gauss1D(pdf)
     Hist1D(pdf)
     DataMC(pdf)
     Hist2DContour(pdf)

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -1,5 +1,8 @@
 """
-matplotlib placeholder example.  we can do way better than this.
+Demonstration of DUNE plot style using matplotlib.
+
+Original authors:  Young DUNE plot style task force
+     Comments to:  Authorship & publications board (dune-apb@fnal.gov)
 """
 
 import numpy as np

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -103,7 +103,12 @@ def DataMC(pdf):
     ratio = counts / fit_at_bin_ctrs
     diff =  counts - fit_at_bin_ctrs
     residuals = diff / fit_at_bin_ctrs
-    chi2 = (diff**2/fit_at_bin_ctrs).sum() / float(bin_centers.size-2)
+    chi2 = (diff**2/fit_at_bin_ctrs).sum()
+
+    # this is the way ROOT counts deg of freedom,
+    # so we mimic it for consistency
+    from inspect import signature
+    ndf = np.count_nonzero(counts > 0) - len(signature(Gauss).parameters)
 
     fig = plt.figure(figsize=(8,6))
     gs = fig.add_gridspec(nrows=2, ncols=1, height_ratios=[3, 1], hspace=0)
@@ -124,12 +129,12 @@ def DataMC(pdf):
              .format(A, dA), transform=axs[0].transAxes)
     axs[0].text(0.70, 0.55, r'$\mu$ = {0:0.2f}$\pm${1:0.2f}'
              .format(x0, dx0), transform=axs[0].transAxes)
-    axs[0].text(0.70, 0.50, r'$\sigma$ = {0:0.1f}$\pm${1:0.1f}'
+    axs[0].text(0.70, 0.50, r'$\sigma$ = {0:0.2f}$\pm${1:0.2f}'
              .format(sig, dsig), transform=axs[0].transAxes)
-    axs[0].text(0.70, 0.40, '$\chi^2/ndof$ = {0:0.2f}'
-             .format(chi2),transform=axs[0].transAxes)
+    axs[0].text(0.70, 0.40, '$\chi^2/ndof$ = {0:0.2f}/{1:d}'
+             .format(chi2, ndf),transform=axs[0].transAxes)
     axs[0].spines[:].set_color('black')
-    axs[0].legend()
+    axs[0].legend(fontsize="x-large")  # since the upper panel is only 70% of the whole canvas, the legend is (by default) too
     axs[0].set_xlim(-5,5)
     axs[0].set_ylim(bottom=0)
     dunestyle.CornerLabel("MC/Data Comparison Example", ax=axs[0])

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -8,13 +8,14 @@ from scipy.optimize import curve_fit
 from matplotlib import pyplot as plt
 from matplotlib.patches import Ellipse
 import matplotlib.gridspec as gridspec
+from matplotlib.backends.backend_pdf import PdfPages
 
 import dunestyle.matplotlib as dunestyle
 
 from plotting_helpers import Gauss, CovEllipse
 
 ### Simple 1D Gaussian example ###
-def Gauss1D():
+def Gauss1D(pdf):
     x = np.linspace(-5, 5, 500)
     y = scipy.stats.norm.pdf(x)
 
@@ -35,9 +36,10 @@ def Gauss1D():
     dunestyle.WIP()
     dunestyle.SimulationSide()
     plt.savefig("example.matplotlib.gaus.png")
+    pdf.savefig()
 
 ### 1D histogram example ###
-def Hist1D():
+def Hist1D(pdf):
     x = np.random.normal(0, 1, 1000)
 
 
@@ -54,6 +56,7 @@ def Hist1D():
     dunestyle.WIP()
     dunestyle.SimulationSide()
     plt.savefig("example.matplotlib.hist1D.png")
+    pdf.savefig()
 
 ### Data/MC example ###
 # Gaus fits are not as straightforward in matplotlib as they are
@@ -63,7 +66,7 @@ def Hist1D():
 # This example saves a Gaussian as a numpy histogram, but this isn't 
 # strictly necessary. It just makes data manipulation easier and 
 # allows us to manipulate the histogram data without drawing it
-def DataMC():
+def DataMC(pdf):
     mu, sigma = 0, 1
     np.random.seed(89)
     x_gaus = np.random.normal(mu, sigma, 10000)
@@ -132,8 +135,9 @@ def DataMC():
     ax1.set_ylim(-1,1)
     ax1.spines[:].set_color('black')
     plt.savefig("example.matplotlib.datamc.png")
+    pdf.savefig()
 
-def Hist2DContour():
+def Hist2DContour(pdf):
     mean = (0, 0)
     cov = [[0.5,-0.5],[-0.5,1]]
     throws = np.random.multivariate_normal(mean, cov, 10000000)
@@ -175,9 +179,10 @@ def Hist2DContour():
     dunestyle.Simulation(x=1.15) # Shift slightly right 
     plt.legend()
     plt.savefig("example.matplotlib.hist2D.png")
+    pdf.savefig()
 
 ### Stacked histogram example ###
-def HistStacked():
+def HistStacked(pdf):
     x1 = np.random.normal( 0, 1, 1000)
     x2 = np.random.normal( 1, 1, 1000)
     x3 = np.random.normal(-1, 1, 1000)
@@ -196,9 +201,10 @@ def HistStacked():
     dunestyle.SimulationSide()
     plt.legend()
     plt.savefig("example.matplotlib.histstacked.png")
+    pdf.savefig()
 
 ### Overlayed histogram example ###
-def HistOverlay():
+def HistOverlay(pdf):
     x1 = np.random.normal( 0, 1, 1000)
     x2 = np.random.normal( 2, 1, 1000)
     x3 = np.random.normal(-2, 1, 1000)
@@ -217,11 +223,16 @@ def HistOverlay():
     dunestyle.SimulationSide()
     plt.legend()
     plt.savefig("example.matplotlib.histoverlay.png")
+    pdf.savefig()
 
 if __name__ == '__main__':
-    Gauss1D()
-    Hist1D()
-    DataMC()
-    Hist2DContour()
-    HistStacked()
-    HistOverlay()
+    pdf = PdfPages("example.matplotlib.pdf")
+
+    Gauss1D(pdf)
+    Hist1D(pdf)
+    DataMC(pdf)
+    Hist2DContour(pdf)
+    HistStacked(pdf)
+    HistOverlay(pdf)
+
+    pdf.close()

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -26,7 +26,7 @@ def Hist1D(pdf):
 
     plt.figure()
     ax = plt.axes()
-    plt.hist(x, histtype='step', label="Hist", linewidth=2)
+    plt.hist(x, histtype='step', label="Hist", range=(-5, 5), bins=50)
     plt.xlabel('x label')
     plt.ylabel('y label')
     plt.xlim(-5,5)
@@ -109,7 +109,6 @@ def DataMC(pdf):
              .format(sig, dsig), transform=axs[0].transAxes)
     axs[0].text(0.70, 0.40, '$\chi^2/ndof$ = {0:0.2f}/{1:d}'
              .format(chi2, ndf),transform=axs[0].transAxes)
-    axs[0].spines[:].set_color('black')
     axs[0].legend(fontsize="x-large")  # since the upper panel is only 70% of the whole canvas, the legend is (by default) too
     axs[0].set_xlim(-5,5)
     axs[0].set_ylim(bottom=0)
@@ -122,7 +121,6 @@ def DataMC(pdf):
     axs[1].set_xlabel("x label")
     axs[1].set_ylabel("(Data - Fit)/Fit")
     axs[1].set_ylim(-0.99,0.99)
-    axs[1].spines[:].set_color('black')
 
     for ax in axs:
         ax.label_outer()
@@ -155,15 +153,12 @@ def Hist2DContour(pdf):
     cyc = cyc()
     for nsig in range(1,4):
         ellipse = CovEllipse(throws[:,0], throws[:,1], cov, nsig=nsig,
-                             label=r"{0}$\sigma$".format(nsig),
-                             linewidth=2, **next(cyc))
+                             label=r"{0}$\sigma$".format(nsig), **next(cyc))
         ax.add_patch(ellipse)
 
     ax.set_xlabel("x label")
     ax.set_ylabel("y label")
-    ax.spines[:].set_color('black')
-    dunestyle.CornerLabel("2D Histogram Example")
-    dunestyle.Simulation(x=1.15) # Shift slightly right 
+    dunestyle.Simulation()
     plt.legend()
     plt.savefig("example.matplotlib.hist2D.png")
     pdf.savefig()
@@ -175,9 +170,8 @@ def HistStacked(pdf):
     nbins = 100
     plt.figure()
     ax = plt.axes()
-    ax.spines[:].set_color('black')
     hist_labels = ["Hist #{0}".format(i+1) for i in range(len(x))]
-    plt.hist(x, nbins, histtype='stepfilled', stacked=True, linewidth=2, label=hist_labels)
+    plt.hist(x, nbins, histtype='stepfilled', stacked=True, label=hist_labels)
     plt.xlabel('x label')
     plt.ylabel('y label')
     ax.set_xlim(-2*(N_HISTS/2+2), 2*N_HISTS)
@@ -196,8 +190,7 @@ def HistOverlay(pdf):
     nbins = 100
     plt.figure()
     ax = plt.axes()
-    ax.spines[:].set_color('black')
-    plt.hist(x, nbins, histtype='step', linewidth=2, label=hist_labels)
+    plt.hist(x, nbins, histtype='step', label=hist_labels)
     plt.xlabel('x label')
     plt.ylabel('y label')
     ax.set_xlim(-2*(N_HISTS/2+2), 2*N_HISTS)

--- a/examples/matplotlib/example.py
+++ b/examples/matplotlib/example.py
@@ -10,9 +10,14 @@ from matplotlib.patches import Ellipse
 import matplotlib.gridspec as gridspec
 from matplotlib.backends.backend_pdf import PdfPages
 
+from cycler import cycler
+
 import dunestyle.matplotlib as dunestyle
 
 from plotting_helpers import Gauss, CovEllipse
+
+# how many histograms to draw in multi-hist plots
+N_HISTS = 8   # exhibits all the colors in the Okabe-Ito cycler
 
 ### Simple 1D Gaussian example ###
 def Gauss1D(pdf):
@@ -186,19 +191,17 @@ def Hist2DContour(pdf):
 
 ### Stacked histogram example ###
 def HistStacked(pdf):
-    x1 = np.random.normal( 0, 1, 1000)
-    x2 = np.random.normal( 1, 1, 1000)
-    x3 = np.random.normal(-1, 1, 1000)
-    nbins = 50
+    hist_extent = (N_HISTS-1)
+    x = [np.random.normal(i, 1, 10000) for i in range(-hist_extent, hist_extent+2, 2)]
+    nbins = 100
     plt.figure()
     ax = plt.axes()
     ax.spines[:].set_color('black')
-    # Can choose one of matplotlib's built-in color patlettes if you prefer
-    plt.style.use('tableau-colorblind10')
-    hist_labels = ['One Hist', 'Two Hist', 'Three Hist']
-    plt.hist([x1,x2,x3], nbins, histtype='stepfilled', stacked=True, linewidth=2, label=hist_labels)
+    hist_labels = ["Hist #{0}".format(i+1) for i in range(len(x))]
+    plt.hist(x, nbins, histtype='stepfilled', stacked=True, linewidth=2, label=hist_labels)
     plt.xlabel('x label')
     plt.ylabel('y label')
+    ax.set_xlim(-2*(N_HISTS/2+2), 2*N_HISTS)
     ax.set_ylim(0, 1.2*ax.get_ylim()[1])
     dunestyle.WIP()
     dunestyle.SimulationSide()
@@ -208,19 +211,17 @@ def HistStacked(pdf):
 
 ### Overlayed histogram example ###
 def HistOverlay(pdf):
-    x1 = np.random.normal( 0, 1, 1000)
-    x2 = np.random.normal( 2, 1, 1000)
-    x3 = np.random.normal(-2, 1, 1000)
-    nbins = 25
+    hist_extent = (N_HISTS-1)
+    x = [np.random.normal(i, 1, 10000) for i in range(-hist_extent, hist_extent+2, 2)]
+    hist_labels = ["Hist #{0}".format(i+1) for i in range(len(x))]
+    nbins = 100
     plt.figure()
     ax = plt.axes()
     ax.spines[:].set_color('black')
-    plt.style.use('tableau-colorblind10')
-    plt.hist(x1, nbins, histtype='step', linewidth=2, label="One Hist")
-    plt.hist(x2, nbins, histtype='step', linewidth=2, label="Two Hist")
-    plt.hist(x3, nbins, histtype='step', linewidth=2, label="Three Hist")
+    plt.hist(x, nbins, histtype='step', linewidth=2, label=hist_labels)
     plt.xlabel('x label')
     plt.ylabel('y label')
+    ax.set_xlim(-2*(N_HISTS/2+2), 2*N_HISTS)
     ax.set_ylim(0, 1.2*ax.get_ylim()[1])
     dunestyle.WIP()
     dunestyle.SimulationSide()

--- a/examples/matplotlib/plotting_helpers.py
+++ b/examples/matplotlib/plotting_helpers.py
@@ -4,8 +4,8 @@ import numpy as np
 import scipy.stats 
 from matplotlib.patches import Ellipse
 
-def Gauss(x, H, A, x0, sigma):
-    return H + A * np.exp(-(x - x0) ** 2 / (2 * sigma ** 2))
+def Gauss(x, A, x0, sigma):
+    return A * np.exp(-(x - x0) ** 2 / (2 * sigma ** 2))
 
 def CovEllipse(xdata, ydata, cov, q=None, nsig=None, facecolor='none', **kwargs):
     """

--- a/examples/root/cpp/example.C
+++ b/examples/root/cpp/example.C
@@ -16,8 +16,6 @@
 void example()
 {
 
-  dunestyle::ColorBlindPalette();
-
   TCanvas c;
 
   // 1D histogram example

--- a/examples/root/cpp/example.C
+++ b/examples/root/cpp/example.C
@@ -33,16 +33,14 @@ void example()
   // 1D data/mc comparison type plot
   c.Clear();
   TH1D* h1D_ratio = (TH1D*)h1D->Clone("h1D_ratio");
-  TPad p1("p1","p1",0.,0.35,1.,1.);
-  TPad p2("p2","p2",0.,0.,1.,0.35);
-  p1.SetBottomMargin(0.04);
-  p1.SetTopMargin(0.15);
-  p2.SetBottomMargin(0.3);
-  p2.SetTopMargin(0.04);
-  c.cd(); p1.Draw(); p1.cd();
+  TPad * p1;
+  TPad * p2;
+  p1 = p2 = nullptr;
+  dunestyle::SplitCanvas(&c, 0.3, p1, p2);
+  c.cd(); p1->Draw(); p1->cd();
   h1D->GetXaxis()->SetLabelSize(0.);
   h1D_ratio->GetXaxis()->SetTitleOffset(1.25);
-  h1D_ratio->GetYaxis()->SetTitle("ratio to fit");
+  h1D_ratio->GetYaxis()->SetTitle("(Data - Fit)/Fit");
   leg->Clear();
   h1D->Fit("gaus");
   h1D->Draw("E");
@@ -51,13 +49,14 @@ void example()
   leg->AddEntry(fit,"fit","l");
   leg->Draw();
   h1D_ratio->Sumw2();
+  h1D_ratio->Add(fit, -1);
   h1D_ratio->Divide(fit);
-  TF1 one("one","1.",-5,5);
+  TF1 zero("zero","0.",-5,5);
   dunestyle::CornerLabel("MC/Data Comparison Example");
-  c.cd(); p2.Draw(); p2.cd();
-  h1D_ratio->GetYaxis()->SetRangeUser(0.,2.);
+  c.cd(); p2->Draw(); p2->cd();
+  h1D_ratio->GetYaxis()->SetRangeUser(-1.,1.);
   h1D_ratio->Draw("E");
-  one.Draw("same");
+  zero.Draw("same");
   c.Print("example.root.pdf");
 
   // 2D histogram example

--- a/examples/root/cpp/example.C
+++ b/examples/root/cpp/example.C
@@ -1,6 +1,9 @@
 ///
-/// ROOT placeholder example.  Work in progress.
+/// Demonstration of DUNE plot style using C++ ROOT.
 ///
+/// Original authors:  Young DUNE plot style task force
+/// Comments to:  Authorship & publications board (dune-apb@fnal.gov)
+
 
 #include "TCanvas.h"
 #include "TFrame.h"
@@ -72,7 +75,6 @@ void DataMCExample(TCanvas * c)
   p1 = p2 = nullptr;
   dunestyle::SplitCanvas(c, 0.3, p1, p2);
   c->cd(); p1->Draw(); p1->cd();
-  h1D->GetXaxis()->SetLabelSize(0.);
   h1D_ratio->GetXaxis()->SetTitleOffset(1.25);
   h1D_ratio->GetYaxis()->SetTitle("(Data - Fit)/Fit");
   leg->Clear();

--- a/examples/root/python/example.py
+++ b/examples/root/python/example.py
@@ -1,118 +1,224 @@
-'''
-PyROOT examples.
-'''
+"""
+Demonstration of DUNE plot style using PyROOT.
+(These are simple translations of the C++ script in ../cpp/example.C.)
+
+Original authors:  Young DUNE plot style task force
+     Comments to:  Authorship & publications board (dune-apb@fnal.gov)
+"""
+
+import ctypes
 import ROOT
-import numpy as np
 
 import dunestyle.root as dunestyle
 
 ROOT.gROOT.SetBatch(True)
+ROOT.EnableThreadSafety()
 
-c = ROOT.TCanvas()
+#ROOT.gInterpreter.Declare('TF1 f("f", "gaus(0)", -100, 100, 1);')
 
-# 1D histogram example
-h1D = ROOT.TH1D('example1d', ';x label;y label', 50, -5, 5)
-h1D.FillRandom('gaus',1000)
-leg = ROOT.TLegend(0.6,0.65,0.8,0.8)
-leg.AddEntry('example1d','1D histogram','l')
-h1D.Draw()
-leg.Draw()
-dunestyle.CenterTitles(h1D)
-dunestyle.WIP()
-dunestyle.SimulationSide()
-c.Print('example.pyroot.pdf(')
+f = ROOT.TF1("f", "gaus(0)", -100, 100, 1)
 
-# 1D data/mc comparison type plot
-c.Clear()
-h1D_ratio = h1D.Clone('h1D_ratio')
-p1 = ROOT.TPad('p1','p1',0.,0.35,1.,1.)
-p2 = ROOT.TPad('p2','p2',0.,0.,1.,0.35)
-p1.SetBottomMargin(0.04)
-p1.SetTopMargin(0.15)
-p2.SetBottomMargin(0.3)
-p2.SetTopMargin(0.04)
-c.cd(); p1.Draw(); p1.cd()
-h1D.GetXaxis().SetLabelSize(0.)
-h1D_ratio.GetXaxis().SetTitleOffset(1.25)
-h1D_ratio.GetYaxis().SetTitle('ratio to fit')
-leg.Clear()
-h1D.Fit('gaus')
-h1D.Draw('E')
-fit = h1D.GetFunction('gaus')
-leg.AddEntry(h1D,'data','lep')
-leg.AddEntry(fit,'fit','l')
-leg.Draw()
-h1D_ratio.Sumw2()
-h1D_ratio.Divide(fit)
-one = ROOT.TF1('one','1.',-5,5)
-dunestyle.CornerLabel('MC/Data Comparison Example')
-c.cd(); p2.Draw(); p2.cd()
-h1D_ratio.GetYaxis().SetRangeUser(0.,2.)
-h1D_ratio.Draw('E')
-one.Draw('same')
-c.Print('example.pyroot.pdf')
+# save a lot of useless repetitive typing
+def MakeLegend(left=0.7, bottom=0.5, right=0.9, top=0.85):
+	leg = ROOT.TLegend(left, bottom, right, top)
+	leg.SetFillStyle(0)  # unfortunately can't set this in TStyle :(
+	return leg
 
-# 2D histogram example
-c.Clear()
-h2D = ROOT.TH2D('example2d', ';x label;y label', 100, -5, 5, 100, -5, 5)
-mean = (0,0)
-cov = [[0.5,-0.5],[-0.5,1]]
-throws = np.random.multivariate_normal(mean, cov, 10000000)
-for throw in throws: h2D.Fill(throw[0],throw[1])
-h2D.Draw('colz')
-dunestyle.CenterTitles(h2D)
-dunestyle.Simulation()
-dunestyle.CornerLabel('2D Histogram Example')
-c.Print('example.pyroot.pdf')
+#-------------------------------------------------------------------
+# enables us to reuse the histograms rather than regenerating every time
+def GaussHists(nHists=dunestyle.colors.kColorCycles.at(ctypes.c_int(dunestyle.colors.Cycle.OkabeIto)).size()):
+	hists = []
+	f.SetParameter(0, 1)  # normalization constant
+	f.SetParameter(2, 1)  # sigma
+	for histIdx in range(nHists):
+		ROOT.f.SetParameter(1, 2*int(histIdx) - (int(nHists)-1))
+		hists.append(ROOT.TH1D("hs%u" % (histIdx+1), ";x label;y label", 100, -2*(nHists/2.+2), 2*nHists))
+		hists[-1].FillRandom("f", 10000)
+	return hists
+#-------------------------------------------------------------------
+def OneDHistExample(c):
+	h1D = ROOT.TH1D("example1d", ";x label;y label", 50, -5, 5)
+	ROOT.SetOwnership(h1D, False)
+	h1D.FillRandom("gaus", 1000)
+	h1D.Draw()
+	h1D.SetMaximum(h1D.GetMaximum()*1.25)  # make room for watermark
+	dunestyle.CenterTitles(h1D)
+	dunestyle.Simulation()
 
-# 2D contour example
-c.Clear()
-leg.Clear()
-level1 = 500.
-level2 = 5000.
-level3 = 25000.
-levels = np.array([level1,level2,level3])
-h2D.SetContour(3,levels)
-palette = h2D.GetListOfFunctions().FindObject('palette')
-l1_h = ROOT.TH1I('l1_h','l1_h',1,0,1)
-l1_h.SetFillColor(palette.GetValueColor(h2D.GetContourLevel(0)))
-# doesn't work?
-#l1_h = ROOT.TH1I('l1_h','l1_h',1,0,1)
-#l1_h.SetFillColor(palette.GetValueColor(h2D.GetContourLevel(1)))
-l2_h = ROOT.TH1I('l2_h','l2_h',1,0,1)
-l2_h.SetFillColor(palette.GetValueColor((h2D.GetContourLevel(2)-h2D.GetContourLevel(0))/2.))
-l3_h = ROOT.TH1I('l3_h','l3_h',1,0,1)
-l3_h.SetFillColor(palette.GetValueColor(h2D.GetContourLevel(2)))
-leg.AddEntry(l1_h,'level 1 contour','f')
-leg.AddEntry(l2_h,'level 2 contour','f')
-leg.AddEntry(l3_h,'level 3 contour','f')
-h2D.Draw('cont1')
-leg.Draw()
-dunestyle.CenterTitles(h2D)
-dunestyle.Simulation()
-dunestyle.SimulationSide()
-dunestyle.CornerLabel('2D Contour Example')
-c.Print('example.pyroot.pdf')
+#-------------------------------------------------------------------
+def DataMCExample(c):
+	""" 1D data/mc comparison type plot """
+	c.cd()
+	c.Clear()
+	leg = MakeLegend(0.65, 0.7, 0.9, 0.85)
+	ROOT.SetOwnership(leg, False)
+	
+	h1D = ROOT.TH1D("exampledata", ";x label;y label", 50, -5, 5)
+	ROOT.SetOwnership(h1D, False)
+	h1D.FillRandom("gaus", 1000)
+	dunestyle.CenterTitles(h1D)
+	
+	h1D_ratio = h1D.Clone("h1D_ratio")
+	ROOT.SetOwnership(h1D_ratio, False)
+	p1 = ROOT.TPad()
+	ROOT.SetOwnership(p1, False)
+	p2 = ROOT.TPad()
+	ROOT.SetOwnership(p2, False)
+	dunestyle.SplitCanvas(c, 0.3, p1, p2)
+	c.cd(); p1.Draw(); p1.cd()
+	h1D_ratio.GetXaxis().SetTitleOffset(1.25)
+	h1D_ratio.GetYaxis().SetTitle("(Data - Fit)/Fit")
+	leg.Clear()
+	h1D.Fit("gaus", "Q")
+	h1D.Draw("E")
+	fit = h1D.GetFunction("gaus")
+	leg.AddEntry(h1D,"Data","lep")
+	leg.AddEntry(fit,"Fit","l")
+	leg.Draw()
+	h1D.GetYaxis().SetRangeUser(h1D.GetMinimum(), h1D.GetMaximum()*1.35)  # make room for watermark
+	dunestyle.Preliminary()
+	
+	h1D_ratio.Sumw2()
+	h1D_ratio.Add(fit, -1)
+	h1D_ratio.Divide(fit)
+	zero = ROOT.TF1("zero","0.",-5,5)
+	ROOT.SetOwnership(zero, False)
+	dunestyle.CenterTitles(h1D_ratio)
+	c.cd(); p2.Draw(); p2.cd()
+	h1D_ratio.GetYaxis().SetRangeUser(-1.,1.)
+	h1D_ratio.Draw("E")
+	zero.Draw("same")
+	
+	p1.cd()
+	pave = ROOT.TPaveText(0.6, 0.45, 0.85, 0.65, "NDC NB")
+	ROOT.SetOwnership(pave, False)
+	pave.SetBorderSize(0)
+	pave.SetFillStyle(0)
+	head = pave.AddText("Gauss Fit Parameters:")
+	head.SetTextFont(62)
+	pave.AddText("A = %.2f #pm %.2f" % (fit.GetParameter(0), fit.GetParError(0)))
+	pave.AddText("#mu = %.2f #pm %.2f" % (fit.GetParameter(1), fit.GetParError(1)))
+	pave.AddText("#sigma = %.2f #pm %.2f" % (fit.GetParameter(2), fit.GetParError(2)))
+	pave.AddText("")
+	pave.AddText("#chi^{2}/ndof = %.2f/%d" % (fit.GetChisquare(), fit.GetNDF()))
+	pave.Draw()
+	
+#-------------------------------------------------------------------
+def TwoDExample(c):
+	c.Clear()
+	c.cd()
+	leg = MakeLegend(0.7, 0.65, 0.9, 0.85)
+	ROOT.SetOwnership(leg, False)
 
-# stacked histogram
-c.Clear()
-leg.Clear()
-hstack = ROOT.THStack('examplestack', ';x label;y label')
-hs1 = ROOT.TH1D('hs1', ';x label;y label', 100, -5, 5)
-hs2 = ROOT.TH1D('hs2', ';x label;y label', 100, -5, 5)
-hs3 = ROOT.TH1D('hs3', ';x label;y label', 100, -5, 5)
-hs1.FillRandom('gaus',10000)
-hs2.FillRandom('gaus',5000)
-hs3.FillRandom('gaus',1000)
-hstack.Add(hs1)
-hstack.Add(hs2)
-hstack.Add(hs3)
-hstack.Draw('pfc')
-leg.SetHeader('Stacked Histograms')
-leg.AddEntry('hs1','one hist','f')
-leg.AddEntry('hs2','two hist','f')
-leg.AddEntry('hs3','three hist','f')
-leg.Draw()
-dunestyle.CornerLabel('Stacked Histograms Example')
-c.Print('example.pyroot.pdf)')
+	h2d = ROOT.TH2D("example2d", ";x label;y label", 100, -5, 5, 120, -5, 7)
+	ROOT.SetOwnership(h2d, False)
+	cust_gaus_2d = ROOT.TF2("cust_gaus_2d","ROOT::Math::bigaussian_pdf(x,y,0.5,1.0,-0.5,0,0)")
+	ROOT.SetOwnership(cust_gaus_2d, False)
+	h2d.FillRandom("cust_gaus_2d", int(1e7))
+	dunestyle.CenterTitles(h2d)
+	h2d.Draw("colz")
+	dunestyle.Simulation()
 
+	# compute the contour levels.
+	# this is a clumsy way of getting the cumulative distribution function
+	tmp = ROOT.TH1D("tmp", "tmp", int(h2d.GetMaximum()+1), 0, h2d.GetMaximum()+1)
+	for i in range(h2d.GetNcells()+1):
+		tmp.Fill(h2d.GetBinContent(i), h2d.GetBinContent(i))
+	cutoffs = [0.997, 0.954, 0.682]
+	levels = []
+	runSum = 0
+	for i in range(tmp.GetNcells()):
+		if len(levels) > 2:
+			break
+		if tmp.Integral(i, tmp.GetNcells()+1) < cutoffs[len(levels)]*h2d.Integral():
+			levels.append(i)
+
+	# now that we have them, draw them
+	linestyles = [ROOT.kSolid, ROOT.kDashed, ROOT.kDotted]
+	for sigma in (1, 2, 3):
+		graphs = dunestyle.GetContourGraphs(h2d, levels[3-sigma])
+		color = dunestyle.colors.NextColor()
+		for g in graphs:
+			ROOT.SetOwnership(g, False)
+			g.SetLineColor(color)
+			g.SetLineStyle(linestyles[sigma-1])
+			g.Draw("same")
+		leg.AddEntry(graphs.back(), "%u#sigma" % sigma, "l")
+	leg.Draw()
+
+
+#-------------------------------------------------------------------
+def StackedExample(c, hists):
+	# stacked histogram
+	c.Clear()
+	c.cd()
+	leg = MakeLegend(0.68, 0.45, 0.9, 0.87)
+	ROOT.SetOwnership(leg, False)
+
+	hstack = ROOT.THStack("examplestack", ";x label; y label")
+	ROOT.SetOwnership(hstack, False)
+	if len(hists) == 0:
+		hists = GaussHists()
+	for histIdx, h in enumerate(hists):
+		ROOT.SetOwnership(h, False)
+		color = dunestyle.colors.NextColor(dunestyle.colors.Cycle.OkabeIto, 0 if histIdx==0 else -1)
+		h.SetLineColor(color)
+		h.SetFillColor(color)
+		hstack.Add(h.Clone(h.GetName()))
+
+		# we do this the hard way so the legend has the top-most histogram in the stack first
+		leg.GetListOfPrimitives().AddFirst(ROOT.TLegendEntry(h, "Hist #%u" % (histIdx+1), "f"))
+	hstack.Draw()
+	leg.Draw()
+
+	hstack.SetMaximum(hstack.GetMaximum()*1.25)   # make some room for the watermark
+	dunestyle.CenterTitles(hstack.GetHistogram())
+	dunestyle.WIP()
+
+#-------------------------------------------------------------------
+def OverlayExample(c, hists):
+	c.Clear()
+	c.cd()
+	leg = MakeLegend(0.68, 0.45, 0.9, 0.87)
+	ROOT.SetOwnership(leg, False)
+
+	if len(hists) == 0:
+		hists = GaussHists()
+	hFirst = None
+	for histIdx, h in enumerate(hists):
+		color = dunestyle.colors.NextColor(dunestyle.colors.Cycle.OkabeIto, 0 if histIdx==0 else -1)
+		h.SetLineColor(color)
+		h.SetFillStyle(0)
+		dunestyle.CenterTitles(h)
+		newh = h.DrawCopy("" if histIdx == 0 else "same")
+		if hFirst is None:
+			hFirst = newh
+		# we do this the hard way so the legend has the top-most histogram in the stack first
+		leg.GetListOfPrimitives().AddFirst(ROOT.TLegendEntry(newh, "Hist #%u" % (histIdx+1), "l"))
+	c.RedrawAxis();  # otherwise the last histogram drawn overlaps with the frame
+	leg.Draw()
+
+	hFirst.SetMaximum(hFirst.GetMaximum()*1.25) # make some space for the watermark
+	dunestyle.WIP()
+
+#-------------------------------------------------------------------
+#-------------------------------------------------------------------
+if __name__ == "__main__":
+	c = ROOT.TCanvas()
+	OneDHistExample(c)
+	c.SaveAs("example.pyroot.pdf(")
+
+	DataMCExample(c)
+	c.SaveAs("example.pyroot.pdf")
+
+	TwoDExample(c)
+	c.SaveAs("example.pyroot.pdf")
+
+	# otherwise ROOT tries to use GSL, which the user may or may not have built
+	ROOT.Math.IntegratorOneDimOptions.SetDefaultIntegrator("Gauss")
+	hists = GaussHists()
+	StackedExample(c, hists)
+	c.Print("example.pyroot.pdf")
+
+	OverlayExample(c, hists)
+	c.Print("example.pyroot.pdf)")

--- a/src/matplotlib/python/dunestyle.py
+++ b/src/matplotlib/python/dunestyle.py
@@ -40,18 +40,26 @@ def WIP(transform=None):
 	     fontdict={"fontsize": 12, "color": "blue"},
 	     transform=transform if transform is not None else plt.gca().transAxes)
 
-def Simulation(x=1.0, y=1.05, align='right', transform=None):
+def Simulation(x=1.0, y=1.05, align='right', ax=None, transform=None):
     #plt.text(1.0, 1.05, r"DUNE Simulation", horizontalalignment='right',
-    plt.text(x, y, r"DUNE Simulation", horizontalalignment=align,
-	     fontdict={"fontsize": 18, "color": "gray"},
-	     transform=transform if transform is not None else plt.gca().transAxes)
+    plotter = plt if ax is None else ax
+    plotter.text(x, y, r"DUNE Simulation", horizontalalignment=align,
+                 fontdict={"fontsize": 18, "color": "gray"},
+                 transform=transform if transform is not None else plt.gca().transAxes)
 
-def SimulationSide(x=1.05, y=0.5, align='right', transform=None):
-    plt.text(1.05, 0.5, r"DUNE Simulation", rotation=270, verticalalignment='center',
-	     fontdict={"fontsize": 18, "color": "gray"},
-	     transform=transform if transform is not None else plt.gca().transAxes)
+def SimulationSide(x=1.05, y=0.5, align='right', ax=None, transform=None):
+    plotter = plt if ax is None else ax
+    plotter.text(1.05, 0.5, r"DUNE Simulation", rotation=270, verticalalignment='center',
+	             fontdict={"fontsize": 18, "color": "gray"},
+	             transform=transform if transform is not None else plt.gca().transAxes)
 
-def CornerLabel(label, transform=None):
-    plt.text(0, 1.05, "{:s}".format(label), horizontalalignment='left',
-	fontdict={"fontsize": 14, "color": "gray"},
-	transform=transform if transform is not None else plt.gca().transAxes)
+def CornerLabel(label, ax=None, transform=None):
+    plotter = plt if ax is None else ax
+    if transform is None:
+        if ax is None:
+            transform = plt.gca().transAxes
+        else:
+            transform = ax.transAxes
+    plotter.text(0, 1.05, "{:s}".format(label), horizontalalignment='left',
+	             fontdict={"fontsize": 14, "color": "gray"},
+	             transform=transform if transform is not None else plt.gca().transAxes)

--- a/src/matplotlib/python/dunestyle.py
+++ b/src/matplotlib/python/dunestyle.py
@@ -35,31 +35,39 @@ if _IMPORT_FLAG_NAME not in builtins.__dict__ or builtins.__dict__[_IMPORT_FLAG_
 
 ##########   Utility functions below  ################
 
-def WIP(transform=None):
-    plt.text(0.05, 0.90, r"DUNE Work In Progress",
-	     fontdict={"fontsize": 12, "color": "blue"},
-	     transform=transform if transform is not None else plt.gca().transAxes)
+""" Used in the text functions below.  don't  """
+def _GetTransform(transform=None, ax=None):
+    if transform is not None:
+        return transform
+    if ax is not None and hasattr(ax, "transAxes"):
+        return ax.transAxes
+    return plt.gca().transAxes
 
-def Simulation(x=1.0, y=1.05, align='right', ax=None, transform=None):
-    #plt.text(1.0, 1.05, r"DUNE Simulation", horizontalalignment='right',
+def TextLabel(text, x, y, transform=None, ax=None, **kwargs):
     plotter = plt if ax is None else ax
-    plotter.text(x, y, r"DUNE Simulation", horizontalalignment=align,
-                 fontdict={"fontsize": 18, "color": "gray"},
-                 transform=transform if transform is not None else plt.gca().transAxes)
+    kwargs.setdefault("fontdict", {})
+    kwargs["fontdict"]["fontsize"] = 18
+    if "color" in kwargs:
+        kwargs["fontdict"]["color"] = kwargs.pop("color")
+    if "fontsize" in kwargs:
+        kwargs["fontdict"]["fontsize"] = kwargs.pop("fontsize")
+    if "align" in kwargs:
+        kwargs["horizontalalignment"] = kwargs.pop("align")
+    plotter.text(x, y, text,
+                 transform=_GetTransform(transform, plotter),
+                 **kwargs)
 
-def SimulationSide(x=1.05, y=0.5, align='right', ax=None, transform=None):
-    plotter = plt if ax is None else ax
-    plotter.text(1.05, 0.5, r"DUNE Simulation", rotation=270, verticalalignment='center',
-	             fontdict={"fontsize": 18, "color": "gray"},
-	             transform=transform if transform is not None else plt.gca().transAxes)
+def Preliminary(x=0.05, y=0.90, align='left', transform=None, ax=None, **kwargs):
+    TextLabel("DUNE Preliminary", x, y, ax=ax, transform=transform, align=align, color="blue", **kwargs)
 
-def CornerLabel(label, ax=None, transform=None):
-    plotter = plt if ax is None else ax
-    if transform is None:
-        if ax is None:
-            transform = plt.gca().transAxes
-        else:
-            transform = ax.transAxes
-    plotter.text(0, 1.05, "{:s}".format(label), horizontalalignment='left',
-	             fontdict={"fontsize": 14, "color": "gray"},
-	             transform=transform if transform is not None else plt.gca().transAxes)
+def WIP(x=0.05, y=0.90, align='left', transform=None, ax=None, **kwargs):
+    TextLabel("DUNE Work In Progress", x, y, ax=ax, transform=transform, align=align, color="blue", **kwargs)
+
+def Simulation(x=0.05, y=0.90, align='left', ax=None, transform=None, **kwargs):
+    TextLabel("DUNE Simulation", x, y, ax=ax, transform=transform, align=align, color="gray", **kwargs)
+
+def SimulationSide(x=1.05, y=0.5, align='right', ax=None, transform=None, **kwargs):
+    TextLabel("DUNE Simulation", x, y, ax=ax, transform=transform, align=align, rotation=270, color="gray", **kwargs)
+
+def CornerLabel(label, ax=None, transform=None, **kwargs):
+    TextLabel(label, 0, 1.05, ax=ax, transform=transform, color="gray", **kwargs)

--- a/src/matplotlib/stylelib/dune.mplstyle
+++ b/src/matplotlib/stylelib/dune.mplstyle
@@ -16,7 +16,7 @@ axes.facecolor: white # eeeeee
 axes.edgecolor: bcbcbc
 axes.grid : False
 axes.titlesize: 36
-axes.labelsize: large
+axes.labelsize: x-large
 
 # Okabe-Ito color scheme.  Original ordering.
 # This ordering unfortunately puts yellow, which is hard to see on projectors,
@@ -51,5 +51,13 @@ grid.linewidth: 0.5
 legend.fontsize: 12
 legend.frameon: False
 
-xtick.direction: in
-ytick.direction: in
+xtick.direction:      in
+xtick.major.size:     10
+xtick.minor.size:     5
+xtick.minor.visible:  True
+xtick.top:            True
+ytick.direction:      in
+ytick.major.size:     10
+ytick.minor.size:     5
+ytick.minor.visible:  True
+ytick.right:          True

--- a/src/matplotlib/stylelib/dune.mplstyle
+++ b/src/matplotlib/stylelib/dune.mplstyle
@@ -20,6 +20,9 @@ axes.labelsize: large
 # Okabelto color scheme 
 axes.prop_cycle: cycler('color', ['000000', 'E69F00', '56B4E9', '009E73', 'F0E442', '0072B2', 'D55E00', 'CC79A7'])
 
+# Cividis is Colo(u)r Vision Deficiency friendly
+image.cmap: cividis
+
 grid.color: b2b2b2
 grid.linestyle: --
 grid.linewidth: 0.5

--- a/src/matplotlib/stylelib/dune.mplstyle
+++ b/src/matplotlib/stylelib/dune.mplstyle
@@ -1,9 +1,10 @@
-## Placeholder matplotlib style file
-## until we have an official DUNE one
+##
+## Style sheet setting the majority of aspects of DUNE style.
+##
 
 lines.linewidth : 2.0
 
-patch.linewidth: 0.5
+patch.linewidth: 2.0    # histograms are "patches"...
 patch.facecolor: blue
 patch.edgecolor: eeeeee
 patch.antialiased: True
@@ -13,10 +14,11 @@ text.hinting_factor : 8
 #mathtext.fontset : cm
 
 axes.facecolor: white # eeeeee
-axes.edgecolor: bcbcbc
-axes.grid : False
-axes.titlesize: 36
+axes.edgecolor: black
+axes.grid :     False
+axes.linewidth: 1.0
 axes.labelsize: x-large
+axes.titlesize: 36
 
 # Okabe-Ito color scheme.  Original ordering.
 # This ordering unfortunately puts yellow, which is hard to see on projectors,
@@ -44,6 +46,7 @@ axes.prop_cycle: cycler('color', ['000000', 'D55E00', '56B4E9', 'E69F00', '009E7
 # Cividis is Colo(u)r Vision Deficiency friendly
 image.cmap: cividis
 
+# grid is off by default (see axes.grid above), but if someone *does* turn it on...
 grid.color: b2b2b2
 grid.linestyle: --
 grid.linewidth: 0.5
@@ -51,11 +54,13 @@ grid.linewidth: 0.5
 legend.fontsize: 12
 legend.frameon: False
 
+xtick.color:          black
 xtick.direction:      in
 xtick.major.size:     10
 xtick.minor.size:     5
 xtick.minor.visible:  True
 xtick.top:            True
+ytick.color:          black
 ytick.direction:      in
 ytick.major.size:     10
 ytick.minor.size:     5

--- a/src/matplotlib/stylelib/dune.mplstyle
+++ b/src/matplotlib/stylelib/dune.mplstyle
@@ -17,8 +17,29 @@ axes.edgecolor: bcbcbc
 axes.grid : False
 axes.titlesize: 36
 axes.labelsize: large
-# Okabelto color scheme 
-axes.prop_cycle: cycler('color', ['000000', 'E69F00', '56B4E9', '009E73', 'F0E442', '0072B2', 'D55E00', 'CC79A7'])
+
+# Okabe-Ito color scheme.  Original ordering.
+# This ordering unfortunately puts yellow, which is hard to see on projectors,
+# fairly high in the list.
+#                                  Black     Orange    Sky blue  Greenish   Yellow   Blue      Vermilion Purplish
+#axes.prop_cycle: cycler('color', ['000000', 'E69F00', '56B4E9', '009E73', 'F0E442', '0072B2', 'D55E00', 'CC79A7', ])
+
+# Okabe-Ito variant #1
+# This version's first 3 non-black colors are basically the DUNE logo colors.
+# (Unfortunately, since the vermilion and sky blue are basically color-opposites,
+#  big swatches of them immediately adjacent may cause some discomfort for color-typical viewers.
+#  We'll see if we get complaints...)
+#                                  Black    Vermilion  Sky blue  Orange   Greenish  Purplish  Blue      Yellow
+axes.prop_cycle: cycler('color', ['000000', 'D55E00', '56B4E9', 'E69F00', '009E73', 'CC79A7', '0072B2', 'F0E442',])
+
+# Okabe-Ito variant #2
+# This one swaps the two blues so the darker one comes first.
+# It's a tad easier to look at than the previous one,
+# but loses the nice "DUNE" theme, and the last 3 colors all have basically the same hue
+# (which would make them indistinguishable for some CVD viewers).
+#                                  Black    Vermilion  Blue     Orange    Greenish  Purplish  Sky Blue  Yellow
+#axes.prop_cycle: cycler('color', ['000000', 'D55E00', '0072B2', 'E69F00', '009E73', 'CC79A7', '56B4E9', 'F0E442',])
+
 
 # Cividis is Colo(u)r Vision Deficiency friendly
 image.cmap: cividis

--- a/src/matplotlib/stylelib/dune.mplstyle
+++ b/src/matplotlib/stylelib/dune.mplstyle
@@ -4,7 +4,7 @@
 
 lines.linewidth : 2.0
 
-patch.linewidth: 2.0    # histograms are "patches"...
+patch.linewidth: 1.5    # histograms are "patches"...
 patch.facecolor: blue
 patch.edgecolor: eeeeee
 patch.antialiased: True

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -116,30 +116,42 @@ namespace dunestyle
   namespace colours = dunestyle::colors;
 
   // Put a "DUNE Work In Progress" tag in the corner
-  TLatex* WIP(ETextAlign labelLoc=kHAlignRight)
+  // default
+  TLatex* WIP(ETextAlign labelLoc=kHAlignLeft, double yLoc=0.87)
   {
     short halign = labelLoc - (labelLoc % 10);
-    float loc = (halign == kHAlignRight) ? 0.85 : ((halign == kHAlignLeft) ? 0.15 : 0.525);
-    TLatex *prelim = new TLatex(loc, 0.92, "DUNE Work In Progress");
+    float loc = (halign == kHAlignRight) ? 0.85 : ((halign == kHAlignLeft) ? 0.17 : 0.525);
+    TLatex *prelim = new TLatex(loc, yLoc, "DUNE Work In Progress");
     prelim->SetTextColor(kBlue);
     prelim->SetNDC();
     prelim->SetTextSize(2 / 30.);
-    prelim->SetTextAlign(halign + kVAlignBottom);
+    prelim->SetTextAlign(halign + kVAlignTop);
     prelim->Draw();
 
     return prelim;
+  }
+
+  // Put a "DUNE Preliminary" tag in the corner
+  void Preliminary()
+  {
+    TLatex *prelim = new TLatex(.18, .86, "DUNE Preliminary");
+    prelim->SetTextColor(kBlue);
+    prelim->SetNDC();
+    prelim->SetTextSize(2 / 30.);
+    prelim->SetTextAlign(kHAlignLeft + kVAlignTop);
+    prelim->Draw();
   }
 
 
   // Put a "DUNE Simulation" tag in the corner
   void Simulation()
   {
-    TLatex *prelim = new TLatex(.9, .95, "DUNE Simulation");
-    prelim->SetTextColor(kGray + 1);
-    prelim->SetNDC();
-    prelim->SetTextSize(2 / 30.);
-    prelim->SetTextAlign(32);
-    prelim->Draw();
+    TLatex *simlabel = new TLatex(.18, .86, "DUNE Simulation");
+    simlabel->SetTextColor(kGray + 1);
+    simlabel->SetNDC();
+    simlabel->SetTextSize(2 / 30.);
+    simlabel->SetTextAlign(kHAlignLeft + kVAlignTop);
+    simlabel->Draw();
   }
 
   // Put a "DUNE Simulation" tag on the right
@@ -350,7 +362,7 @@ namespace dunestyle
     // Extend the left and bottom margins so axis titles don't run off the pad
     duneStyle->SetPadBottomMargin(0.15);
     duneStyle->SetPadLeftMargin(0.15);
-    duneStyle->SetPadRightMargin(0.15);
+    duneStyle->SetPadRightMargin(0.15);  // this is a bit wide in general but means most colorbars won't run off the edge
 
     // Fonts
     const int kDuneFont = 42;

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -92,13 +92,16 @@ namespace dunestyle
     /// A color cycler that runs through colors in order
     ///
     /// \param cycle  The dunestyle::colors::Cycle you want to run through
+    /// \param start  Start cycling from a particular color index.  (-1 continues from previous cycle.)
     /// \return       A color index known to TColor
-    Color_t NextColor(Cycle cycle = Cycle::OkabeIto)
+    Color_t NextColor(Cycle cycle = Cycle::OkabeIto, int start=-1)
     {
       static std::vector<std::size_t> counter(static_cast<std::size_t>(Cycle::NumCycles));
 
       const std::vector<Color_t> & colorVec = kColorCycles.at(cycle);
       auto cycleIdx = static_cast<std::size_t>(cycle);
+      if (start >= 0)
+        counter[cycleIdx] = start % colorVec.size();
       Color_t colorVal = colorVec[counter[cycleIdx]];
       counter[cycleIdx] = (counter[cycleIdx] + 1) % colorVec.size();
 

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -120,74 +120,64 @@ namespace dunestyle
   // ----------------------------------------------------------------------------
   // ----------------------------------------------------------------------------
 
-  // Put a "DUNE Work In Progress" tag in the corner
-  // default
-  TLatex* WIP(ETextAlign labelLoc=kHAlignLeft, double yLoc=0.87)
+  TLatex * TextLabel(const std::string & text, double xLoc, double yLoc, short color=kBlue,
+                     ETextAlign hAlign=kHAlignLeft, ETextAlign vAlign=kVAlignTop)
   {
-    short halign = labelLoc - (labelLoc % 10);
-    float loc = (halign == kHAlignRight) ? 0.85 : ((halign == kHAlignLeft) ? 0.17 : 0.525);
-    TLatex *prelim = new TLatex(loc, yLoc, "DUNE Work In Progress");
-    prelim->SetTextColor(kBlue);
-    prelim->SetNDC();
-    prelim->SetTextSize(2 / 30.);
-    prelim->SetTextAlign(halign + kVAlignTop);
-    prelim->Draw();
+    std::cout << "\ntext='" << text << "'\n";
+    std::cout << "drawing at x=" << xLoc << ", y=" << yLoc << "\n";
+    auto txtObj = new TLatex(xLoc, yLoc, text.c_str());
+    txtObj->SetTextColor(color);
+    txtObj->SetNDC();
+    txtObj->SetTextSize(2 / 30.);
+    std::cout << "halign=" << hAlign << ", valign=" << vAlign << "\n";
+    txtObj->SetTextAlign(hAlign + vAlign);
+    txtObj->Draw();
 
-    return prelim;
+    return txtObj;
+  }
+
+  TLatex * TextLabel(const std::string & text, ETextAlign align, short color=kBlue)
+  {
+    auto hAlign = static_cast<ETextAlign>(align - (align % 10));
+    auto vAlign = static_cast<ETextAlign>(align % 10);
+    float xloc = (hAlign == kHAlignRight) ? 0.85 : ((hAlign == kHAlignLeft) ? 0.18 : 0.525);
+    float yloc = (vAlign == kVAlignTop) ? 0.87 : ((vAlign == kVAlignBottom) ? 0.13 : 0.5);
+    std::cout << "    x=" << xloc << ", y=" << yloc << "\n";
+
+    return TextLabel(text, xloc, yloc, color, hAlign, vAlign);
+  }
+
+  // Put a "DUNE Work In Progress" tag in the upper left corner (by default)
+  TLatex* WIP(ETextAlign loc=static_cast<ETextAlign>(kHAlignLeft + kVAlignTop))
+  {
+    return TextLabel("DUNE Work In Progress", loc, kBlue);
   }
 
   // ----------------------------------------------------------------------------
 
-  // Put a "DUNE Preliminary" tag in the corner
-  void Preliminary()
+  // Put a "DUNE Preliminary" tag in the upper left corner (by default)
+  TLatex* Preliminary(ETextAlign loc=static_cast<ETextAlign>(kHAlignLeft + kVAlignTop))
   {
-    TLatex *prelim = new TLatex(.18, .86, "DUNE Preliminary");
-    prelim->SetTextColor(kBlue);
-    prelim->SetNDC();
-    prelim->SetTextSize(2 / 30.);
-    prelim->SetTextAlign(kHAlignLeft + kVAlignTop);
-    prelim->Draw();
+    return TextLabel("DUNE Preliminary", loc, kBlue);
   }
 
   // ----------------------------------------------------------------------------
 
   // Put a "DUNE Simulation" tag in the corner
-  void Simulation()
+  TLatex* Simulation(ETextAlign loc=static_cast<ETextAlign>(kHAlignLeft + kVAlignTop))
   {
-    TLatex *simlabel = new TLatex(.18, .86, "DUNE Simulation");
-    simlabel->SetTextColor(kGray + 1);
-    simlabel->SetNDC();
-    simlabel->SetTextSize(2 / 30.);
-    simlabel->SetTextAlign(kHAlignLeft + kVAlignTop);
-    simlabel->Draw();
+    return TextLabel("DUNE Simulation", loc, kGray + 1);
   }
 
   // ----------------------------------------------------------------------------
 
   // Put a "DUNE Simulation" tag on the right
-  void SimulationSide()
+  TLatex* SimulationSide()
   {
-    TLatex *prelim = new TLatex(.93, .9, "DUNE Simulation");
-    prelim->SetTextColor(kGray + 1);
-    prelim->SetNDC();
-    prelim->SetTextSize(2 / 30.);
-    prelim->SetTextAngle(270);
-    prelim->SetTextAlign(12);
-    prelim->Draw();
-  }
-
-  // ----------------------------------------------------------------------------
-
-  // Add a label in top left corner
-  // Especially useful for "Neutrino Beam" and "Antineutrino Beam" labels
-  void CornerLabel(std::string Str)
-  {
-    TLatex *CornLab = new TLatex(.1, .93, Str.c_str());
-    CornLab->SetTextColor(kGray + 1);
-    CornLab->SetNDC();
-    CornLab->SetTextSize(2 / 30.);
-    CornLab->SetTextAlign(11);
-    CornLab->Draw();
+    TLatex * label = TextLabel("DUNE Simulation", .93, .9, kGray+1);
+    label->SetTextAngle(270);
+    label->SetTextAlign(12);
+    return label;
   }
 
   // ----------------------------------------------------------------------------

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -123,13 +123,10 @@ namespace dunestyle
   TLatex * TextLabel(const std::string & text, double xLoc, double yLoc, short color=kBlue,
                      ETextAlign hAlign=kHAlignLeft, ETextAlign vAlign=kVAlignTop)
   {
-    std::cout << "\ntext='" << text << "'\n";
-    std::cout << "drawing at x=" << xLoc << ", y=" << yLoc << "\n";
     auto txtObj = new TLatex(xLoc, yLoc, text.c_str());
     txtObj->SetTextColor(color);
     txtObj->SetNDC();
     txtObj->SetTextSize(2 / 30.);
-    std::cout << "halign=" << hAlign << ", valign=" << vAlign << "\n";
     txtObj->SetTextAlign(hAlign + vAlign);
     txtObj->Draw();
 
@@ -142,7 +139,6 @@ namespace dunestyle
     auto vAlign = static_cast<ETextAlign>(align % 10);
     float xloc = (hAlign == kHAlignRight) ? 0.85 : ((hAlign == kHAlignLeft) ? 0.18 : 0.525);
     float yloc = (vAlign == kVAlignTop) ? 0.87 : ((vAlign == kVAlignBottom) ? 0.13 : 0.5);
-    std::cout << "    x=" << xloc << ", y=" << yloc << "\n";
 
     return TextLabel(text, xloc, yloc, color, hAlign, vAlign);
   }

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -75,13 +75,16 @@ namespace dunestyle
     /// If you would like all the colors in one package
     const std::map<Cycle, std::vector<Color_t>> kColorCycles
     {
+        // this ordering differs from the original Okabe-Ito ordering,
+        // which uses yellow (difficult to see on projectors) fairly early in the list.
+        // here we also get the DUNE logo colors in the first 4, which is nice.
         { Cycle::OkabeIto, { kBlack,
-                             kOkabeItoSkyBlue,
                              kOkabeItoVermilion,
-                             kOkabeItoBlueGreen,
+                             kOkabeItoSkyBlue,
                              kOkabeItoOrange,
-                             kOkabeItoBlue,
+                             kOkabeItoBlueGreen,
                              kOkabeItoRedPurple,
+                             kOkabeItoBlue,
                              kOkabeItoYellow }},
     };
     const auto kColourCycles = kColorCycles;   ///< Alias for \ref kColorCycles with BrEng spelling

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -46,6 +46,8 @@ namespace dunestyle
     const TColor __kOIRedPurple(TColor::GetFreeColorIndex(), 0.80, 0.60, 0.70);
   }
 
+  // ----------------------------------------------------------------------------
+
   /// Colo(u)rs we encourage collaborators to use.
   /// N.b.: 'colors' namespace is aliased to 'colours' below in case you prefer BrEng spelling
   namespace colors
@@ -115,6 +117,9 @@ namespace dunestyle
   } // namespace color
   namespace colours = dunestyle::colors;
 
+  // ----------------------------------------------------------------------------
+  // ----------------------------------------------------------------------------
+
   // Put a "DUNE Work In Progress" tag in the corner
   // default
   TLatex* WIP(ETextAlign labelLoc=kHAlignLeft, double yLoc=0.87)
@@ -131,6 +136,8 @@ namespace dunestyle
     return prelim;
   }
 
+  // ----------------------------------------------------------------------------
+
   // Put a "DUNE Preliminary" tag in the corner
   void Preliminary()
   {
@@ -142,6 +149,7 @@ namespace dunestyle
     prelim->Draw();
   }
 
+  // ----------------------------------------------------------------------------
 
   // Put a "DUNE Simulation" tag in the corner
   void Simulation()
@@ -153,6 +161,8 @@ namespace dunestyle
     simlabel->SetTextAlign(kHAlignLeft + kVAlignTop);
     simlabel->Draw();
   }
+
+  // ----------------------------------------------------------------------------
 
   // Put a "DUNE Simulation" tag on the right
   void SimulationSide()
@@ -166,8 +176,10 @@ namespace dunestyle
     prelim->Draw();
   }
 
-// Add a label in top left corner
-// Especially useful for "Neutrino Beam" and "Antineutrino Beam" labels
+  // ----------------------------------------------------------------------------
+
+  // Add a label in top left corner
+  // Especially useful for "Neutrino Beam" and "Antineutrino Beam" labels
   void CornerLabel(std::string Str)
   {
     TLatex *CornLab = new TLatex(.1, .93, Str.c_str());
@@ -178,6 +190,8 @@ namespace dunestyle
     CornLab->Draw();
   }
 
+  // ----------------------------------------------------------------------------
+
   void CenterTitles(TH1 *histo)
   {
     histo->GetXaxis()->CenterTitle();
@@ -185,11 +199,15 @@ namespace dunestyle
     histo->GetZaxis()->CenterTitle();
   }
 
+  // ----------------------------------------------------------------------------
+
   /// Palette friendly to those with Colo(u)r Vision Deficiencies (CVD)
   void CVDPalette()
   {
     gStyle->SetPalette(kCividis);
   }
+
+  // ----------------------------------------------------------------------------
 
   /// A nice monochrome palette (white -> red)
   void CherryInvertedPalette()
@@ -197,6 +215,8 @@ namespace dunestyle
     gStyle->SetPalette(kCherry);
     TColor::InvertPalette();
   }
+
+  // ----------------------------------------------------------------------------
 
   /// A nice bichrome palette (blue -> white -> red):
   /// Recommended for use only when range is symmetric around zero or unity
@@ -222,6 +242,8 @@ namespace dunestyle
     gStyle->SetPalette(n_color_contours, colors);
   }
 
+  // ----------------------------------------------------------------------------
+
   void SplitCanvas(TCanvas * c, double ysplit, TPad*& p1, TPad*& p2)
   {
     c->cd();
@@ -240,6 +262,8 @@ namespace dunestyle
       p->Draw();
     }
   }
+
+  // ----------------------------------------------------------------------------
 
   std::vector<TGraph*> GetContourGraphs(TH2* h2, double level)
   {
@@ -294,6 +318,8 @@ namespace dunestyle
     return ret;
   }
 
+  // ----------------------------------------------------------------------------
+  // ----------------------------------------------------------------------------
 
   bool SetDuneStyle()
   {

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -16,6 +16,7 @@
 #define DUNE_STYLE_H
 
 #include "TColor.h"
+#include "TGraph.h"
 #include "TH1.h"
 #include "TLatex.h"
 #include "TROOT.h"

--- a/src/root/cpp/include/DUNEStyle.h
+++ b/src/root/cpp/include/DUNEStyle.h
@@ -36,13 +36,13 @@ namespace dunestyle
     // look in the `colors` namespace, further down
     // The RGB values are taken from here:
     // https://mikemol.github.io/technique/colorblind/2018/02/11/color-safe-palette.html
-    const TColor __kOIOrange(TColor::GetFreeColorIndex(), 90, 60, 0);
-    const TColor __kOISkyBlue(TColor::GetFreeColorIndex(), 35, 70, 90);
-    const TColor __kOIBlueGreen(TColor::GetFreeColorIndex(), 0, 60, 50);
-    const TColor __kOIYellow(TColor::GetFreeColorIndex(), 95, 90, 25);
-    const TColor __kOIBlue(TColor::GetFreeColorIndex(), 0, 45, 70);
-    const TColor __kOIVermilion(TColor::GetFreeColorIndex(), 80, 40, 0);
-    const TColor __kOIRedPurple(TColor::GetFreeColorIndex(), 80, 60, 70);
+    const TColor __kOIOrange(TColor::GetFreeColorIndex(), 0.90, 0.60, 0);
+    const TColor __kOISkyBlue(TColor::GetFreeColorIndex(), 0.35, 0.70, 0.90);
+    const TColor __kOIBlueGreen(TColor::GetFreeColorIndex(), 0, 0.60, 0.50);
+    const TColor __kOIYellow(TColor::GetFreeColorIndex(), 0.95, 0.90, 0.25);
+    const TColor __kOIBlue(TColor::GetFreeColorIndex(), 0, 0.45, 0.70);
+    const TColor __kOIVermilion(TColor::GetFreeColorIndex(), 0.80, 0.40, 0);
+    const TColor __kOIRedPurple(TColor::GetFreeColorIndex(), 0.80, 0.60, 0.70);
   }
 
   /// Colo(u)rs we encourage collaborators to use.

--- a/src/root/python/dunestyle.py
+++ b/src/root/python/dunestyle.py
@@ -20,6 +20,11 @@ import builtins
 CPP_HEADER = "DUNEStyle.h"
 UPS_VAR = "DUNE_PLOT_STYLE_INC"
 
+# unfortunately child namespaces seem not to be loaded by default
+CHILD_NAMESPACES = [
+	"colors",
+]
+
 
 def enable():
 	import os.path
@@ -54,6 +59,12 @@ def enable():
 		if obj.startswith("_"):
 			continue
 		setattr(sys.modules[__name__], obj, getattr(ROOT.dunestyle, obj))
+
+	for ns in CHILD_NAMESPACES:
+		try:
+			setattr(sys.modules[__name__], ns, getattr(ROOT.dunestyle, ns))
+		except NameError:
+			pass
 
 	print("DUNE plot style enabled")
 


### PR DESCRIPTION
This PR fully implements the Okabe-Ito color cycle (which we'd use for 1D histograms/curves) and sets the default "colz" palette to Cividis.  Both of these changes make the color schemes accessible to those with Colo(u)r Vision Deficiencies by default.

There's also a lot of work here to make the ROOT and Matplotlib examples look much more similar. 