### PR TITLE
Add License and copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 20023, FERMI NATIONAL ACCELERATOR LABORATORY
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This resolves #25.

In particular, this would sign over copyright to Fermilab and put the code under the Apache 2.0 open source license, as recommended by https://docs.dunescience.org/cgi-bin/sso/ShowDocument?docid=27141 .

As this signs over copyright, everyone who touched the code should approve this.